### PR TITLE
docs(TODO): fix checklist bullets and add blank lines for better prev…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,45 +2,53 @@
 
 *Actualizado: 2025-09-23*
 
-[X] Repo inicial y workspace Go configurado
-[X] HTTP mux básico con `/health`
-[X] Hub de difusión (fan‑out) creado
-[X] Servidor WS básico registrado en `/ws`
-[X] Auth MVP (token == userID)
-[X] Keep‑alive WS (ping/pong + timeout)
-[X] Endpoint `/upload` con límite `MaxBytes` y nombre aleatorio
-[X] Tests unitarios de `/upload` en verde
-[X] Ruta `/upload` registrada en el mux
-[X] Tests E2E: WS básico + upload+señal (UploadAndSignal)
-[X] Tests negativos WS: size inconsistente, clip vacío
-[X] Validaciones WS: `len(Data)==Size`, `Size<=MaxInlineBytes`, `UploadURL` si no hay `Data`
-[X] Asignar `mime` por defecto cuando falte
-[X] Rate limit por dispositivo
-[X] Métricas: contadores de clips, drops, conexiones
-[X] Logs estructurados: request id, device, user
-[X] `/healthz` con métricas mínimas
-[X] Cierre amable: `http.Server` con `Shutdown` y drenaje de `Hub`
-[X] Deduplicación opcional por `msg_id` (LRU corta)
-[X] Backpressure visible: contador de descartes por device
-[X] Auth HMAC firmado → `userID` + caducidad
-[ ] Validar `device_id` (formato; opcional registro)
-[ ] `/upload`: permitir solo tipos aceptados
-[ ] Flags/env: puertos, límites, dir uploads, log level
-[ ] `/debug/pprof` y opcional `expvar`
-[X] Makefile/justfile para build/test/run
-[ ] CLI: reconexión exponencial
-[ ] CLI: modo pipe estable (`echo hola | clip-sync --mode send`)
-[ ] CLI: detección simple de mime por extensión
-[ ] CLI: salida limpia y códigos de salida coherentes
-[X] CI (GitHub Actions): lint, `go test ./...`, build server+cli
-[ ] Benchmarks ligeros del Hub
-[ ] Fuzzing del envelope JSON (corpus pequeño)
-[ ] Documentar protocolo (hello, clip inline, `upload_url`)
-[ ] README de arranque rápido (server + 2 CLI)
-[ ] Colección Postman
-[ ] Changelog v1
-[ ] CLI: `watch` monitorea portapapeles y publica por WS
-[ ] CLI: `recv` aplica clips entrantes al portapapeles
-[ ] Clips grandes: subir a `/upload` en `watch` y descargar en `recv`
-[ ] Deduplicación por `msg_id` en server y cliente
-[ ] Binarios para Windows, macOS y Linux
+- [X] Repo inicial y workspace Go configurado
+- [X] HTTP mux básico con `/health`
+- [X] Hub de difusión (fan‑out) creado
+- [X] Servidor WS básico registrado en `/ws`
+- [X] Auth MVP (token == userID)
+- [X] Keep‑alive WS (ping/pong + timeout)
+
+- [X] Endpoint `/upload` con límite `MaxBytes` y nombre aleatorio
+- [X] Tests unitarios de `/upload` en verde
+- [X] Ruta `/upload` registrada en el mux
+- [X] Tests E2E: WS básico + upload+señal (UploadAndSignal)
+
+- [X] Tests negativos WS: size inconsistente, clip vacío
+- [X] Validaciones WS: `len(Data)==Size`, `Size<=MaxInlineBytes`, `UploadURL` si no hay `Data`
+- [X] Asignar `mime` por defecto cuando falte
+- [X] Rate limit por dispositivo
+- [X] Métricas: contadores de clips, drops, conexiones
+- [X] Logs estructurados: request id, device, user
+- [X] `/healthz` con métricas mínimas
+- [X] Cierre amable: `http.Server` con `Shutdown` y drenaje de `Hub`
+- [X] Deduplicación opcional por `msg_id` (LRU corta)
+- [X] Backpressure visible: contador de descartes por device
+- [X] Auth HMAC firmado → `userID` + caducidad
+
+- [ ] Validar `device_id` (formato; opcional registro)
+- [ ] `/upload`: permitir solo tipos aceptados
+- [ ] Flags/env: puertos, límites, dir uploads, log level
+- [ ] `/debug/pprof` y opcional `expvar`
+
+- [X] Makefile/justfile para build/test/run
+- [X] CI (GitHub Actions): lint, `go test ./...`, build server+cli
+
+- [ ] CLI: reconexión exponencial
+- [ ] CLI: modo pipe estable (`echo hola | clip-sync --mode send`)
+- [ ] CLI: detección simple de mime por extensión
+- [ ] CLI: salida limpia y códigos de salida coherentes
+
+- [ ] Benchmarks ligeros del Hub
+- [ ] Fuzzing del envelope JSON (corpus pequeño)
+
+- [ ] Documentar protocolo (hello, clip inline, `upload_url`)
+- [ ] README de arranque rápido (server + 2 CLI)
+- [ ] Colección Postman
+- [ ] Changelog v1
+
+- [ ] CLI: `watch` monitorea portapapeles y publica por WS
+- [ ] CLI: `recv` aplica clips entrantes al portapapeles
+- [ ] Clips grandes: subir a `/upload` en `watch` y descargar en `recv`
+- [ ] Deduplicación por `msg_id` en server y cliente
+- [ ] Binarios para Windows, macOS y Linux


### PR DESCRIPTION
### **User description**
…iew readability


___

### **PR Type**
Documentation


___

### **Description**
- Format checklist bullets with proper markdown syntax

- Add blank lines between task groups for readability

- Improve visual organization of TODO items


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Original TODO"] --> B["Add bullet syntax"]
  B --> C["Group with blank lines"]
  C --> D["Improved readability"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TODO.md</strong><dd><code>Format checklist with bullets and spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TODO.md

<ul><li>Convert plain checklist items to proper markdown bullets<br> <li> Add blank lines between logical task groups<br> <li> Maintain all existing task content and completion status</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/5/files#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986">+54/-46</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

