### PR TITLE
test(server): hub benchmarks + Envelope JSON fuzz seed

### DIFF
--- a/server/internal/hub/hub_bench_test.go
+++ b/server/internal/hub/hub_bench_test.go
@@ -1,0 +1,41 @@
+package hub
+
+import (
+    "testing"
+)
+
+// Benchmark broadcasting to N subscribers with small payloads.
+func BenchmarkHub_Broadcast_Fanout(b *testing.B) {
+    for _, subs := range []int{1, 2, 4, 8, 32, 128} {
+        b.Run("subs="+itoa(subs), func(b *testing.B) {
+            h := New(64)
+            // join N subscribers for same user
+            var leaves []func()
+            for i := 0; i < subs; i++ {
+                _, leave := h.Join("u", itoa(i))
+                leaves = append(leaves, leave)
+            }
+            payload := make([]byte, 256)
+            b.ResetTimer()
+            for i := 0; i < b.N; i++ {
+                h.Broadcast("u", "from", payload)
+            }
+            b.StopTimer()
+            for _, f := range leaves { f() }
+        })
+    }
+}
+
+// local itoa to avoid importing strconv in benchmarks file
+func itoa(n int) string {
+    if n == 0 { return "0" }
+    var buf [32]byte
+    i := len(buf)
+    for n > 0 {
+        i--
+        buf[i] = byte('0' + (n % 10))
+        n /= 10
+    }
+    return string(buf[i:])
+}
+

--- a/server/internal/hub/hub_bench_test.go
+++ b/server/internal/hub/hub_bench_test.go
@@ -1,18 +1,19 @@
 package hub
 
 import (
+    "strconv"
     "testing"
 )
 
 // Benchmark broadcasting to N subscribers with small payloads.
 func BenchmarkHub_Broadcast_Fanout(b *testing.B) {
     for _, subs := range []int{1, 2, 4, 8, 32, 128} {
-        b.Run("subs="+itoa(subs), func(b *testing.B) {
+        b.Run("subs="+strconv.Itoa(subs), func(b *testing.B) {
             h := New(64)
             // join N subscribers for same user
             var leaves []func()
             for i := 0; i < subs; i++ {
-                _, leave := h.Join("u", itoa(i))
+                _, leave := h.Join("u", strconv.Itoa(i))
                 leaves = append(leaves, leave)
             }
             payload := make([]byte, 256)
@@ -24,18 +25,5 @@ func BenchmarkHub_Broadcast_Fanout(b *testing.B) {
             for _, f := range leaves { f() }
         })
     }
-}
-
-// local itoa to avoid importing strconv in benchmarks file
-func itoa(n int) string {
-    if n == 0 { return "0" }
-    var buf [32]byte
-    i := len(buf)
-    for n > 0 {
-        i--
-        buf[i] = byte('0' + (n % 10))
-        n /= 10
-    }
-    return string(buf[i:])
 }
 

--- a/server/pkg/types/fuzz_envelope_test.go
+++ b/server/pkg/types/fuzz_envelope_test.go
@@ -1,0 +1,37 @@
+package types
+
+import (
+    "encoding/json"
+    "testing"
+)
+
+// FuzzEnvelopeJSON ensures that arbitrary JSON inputs do not crash the decoder
+// and that a round-trip encode/decode of accepted inputs is stable enough
+// for our struct shape (we only check absence of panics and basic invariants).
+func FuzzEnvelopeJSON(f *testing.F) {
+    // Seed with a small corpus of realistic messages
+    seeds := [][]byte{
+        []byte(`{"type":"hello","hello":{"token":"u1","user_id":"u1","device_id":"A"}}`),
+        []byte(`{"type":"clip","clip":{"msg_id":"m1","mime":"text/plain","size":2,"data":"aGk=","upload_url":""}}`),
+        []byte(`{"type":"clip","clip":{"msg_id":"m2","mime":"application/octet-stream","size":100000,"upload_url":"/d/abcd"}}`),
+        []byte(`{"type":"hello","hello":{}}`),
+    }
+    for _, s := range seeds { f.Add(string(s)) }
+
+    f.Fuzz(func(t *testing.T, s string) {
+        var env Envelope
+        if err := json.Unmarshal([]byte(s), &env); err != nil {
+            return // ignore invalid JSON
+        }
+        // encode and decode again
+        b, err := json.Marshal(&env)
+        if err != nil { t.Fatalf("marshal: %v", err) }
+        var env2 Envelope
+        _ = json.Unmarshal(b, &env2)
+        // Basic sanity: type field is at most a short label
+        if len(env2.Type) > 64 {
+            t.Skip()
+        }
+    })
+}
+

--- a/server/pkg/types/fuzz_envelope_test.go
+++ b/server/pkg/types/fuzz_envelope_test.go
@@ -32,6 +32,14 @@ func FuzzEnvelopeJSON(f *testing.F) {
         if len(env2.Type) > 64 {
             t.Skip()
         }
+        // Round-trip should preserve type string exactly
+        if env2.Type != env.Type {
+            t.Fatalf("type mismatch after roundtrip: %q vs %q", env.Type, env2.Type)
+        }
+        // If data present, size should match len(data) after round-trip (when not zero)
+        if env2.Clip != nil && len(env2.Clip.Data) > 0 && env2.Clip.Size != len(env2.Clip.Data) {
+            // Don't fail fuzzing hard; mark as interesting and skip
+            t.Skip()
+        }
     })
 }
-


### PR DESCRIPTION
### **User description**
Summary\n- Add lightweight Hub fan-out benchmarks for N subscribers.\n- Add fuzz test for types.Envelope JSON with small seed corpus and round-trip stability.\n\nWhy\n- Benchmarks help track broadcast fan-out behavior under varying subscriber counts.\n- Fuzzing adds resilience against malformed JSON and guards against panics during decode.\n\nNotes\n- Benchmarks and fuzz tests do not run by default in CI (no -bench/-fuzz). Regular test suite remains unchanged.


___

### **PR Type**
Tests


___

### **Description**
- Add hub broadcast benchmarks for N subscribers

- Add envelope JSON fuzz testing with seed corpus

- Include round-trip stability validation for JSON encoding


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hub Benchmarks"] --> B["Broadcast Fan-out Testing"]
  C["Envelope Fuzz Tests"] --> D["JSON Round-trip Validation"]
  B --> E["Performance Tracking"]
  D --> F["Resilience Testing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hub_bench_test.go</strong><dd><code>Hub broadcast performance benchmarks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/internal/hub/hub_bench_test.go

<ul><li>Add benchmark for hub broadcast fan-out with varying subscriber counts<br> <li> Test performance with 1, 2, 4, 8, 32, 128 subscribers<br> <li> Include custom <code>itoa</code> helper function for string conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/11/files#diff-6a27fe3807812b2e1320783a73aafd512ba111427386876c04dc2d56086fc773">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fuzz_envelope_test.go</strong><dd><code>Envelope JSON fuzz testing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

server/pkg/types/fuzz_envelope_test.go

<ul><li>Add fuzz test for <code>Envelope</code> JSON marshaling/unmarshaling<br> <li> Include seed corpus with realistic message examples<br> <li> Validate round-trip stability and basic invariants</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/11/files#diff-9e0081b6911d97e7cbbe2442f69b244976b4c86610a5e8e085099fdb2599b461">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

