### PR TITLE
cli: watch/recv/sync clipboard modes (Windows/Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,22 @@ Flow:
   ```
 * `GET /d/{id}` → streams the stored blob
 
-## CLI (MVP)
+## CLI
 
 ```
 bin/cli --help
 ```
 
-Planned:
+Modes:
+- `listen`: prints incoming clips (debug).
+- `send`: sends `--text`, `--file`, o stdin (pipe estable).
+- `recv`: aplica clips entrantes al portapapeles (text/*).
+- `watch`: monitorea portapapeles local y publica (text/*) con `--poll-ms`.
+- `sync`: combina `watch` + `recv` en un solo proceso (recomendado).
 
-* `send` mode: stdin or `--file` with MIME by extension.
-* Auto reconnect with backoff.
-* Clean logs and exit codes.
+Dependencias de portapapeles:
+- Windows: PowerShell (Get-Clipboard / Set-Clipboard) — ya incluido.
+- Linux: instala `wl-clipboard` (Wayland) o `xclip`/`xsel` (X11).
 
 ## Testing
 

--- a/TODO.md
+++ b/TODO.md
@@ -47,8 +47,8 @@
 - [X] Colección Postman
 - [X] Changelog v1
 
-- [ ] CLI: `watch` monitorea portapapeles y publica por WS
-- [ ] CLI: `recv` aplica clips entrantes al portapapeles
-- [ ] Clips grandes: subir a `/upload` en `watch` y descargar en `recv`
+- [X] CLI: `watch` monitorea portapapeles y publica por WS
+- [X] CLI: `recv` aplica clips entrantes al portapapeles
+- [X] Clips grandes: subir a `/upload` en `watch` y descargar en `recv`
 - [ ] Deduplicación por `msg_id` en server y cliente
 - [ ] Binarios para Windows, macOS y Linux

--- a/clients/cli/clipboard.go
+++ b/clients/cli/clipboard.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+    "bytes"
+    "errors"
+    "fmt"
+    "os/exec"
+    "runtime"
+)
+
+func getClipboardText() (string, error) {
+    if runtime.GOOS == "windows" {
+        // Prefer Windows PowerShell; -Raw keeps text as-is.
+        cmd := exec.Command("powershell", "-NoProfile", "-Command", "Get-Clipboard -Raw")
+        out, err := cmd.CombinedOutput()
+        if err != nil {
+            return "", fmt.Errorf("Get-Clipboard: %v", err)
+        }
+        return string(out), nil
+    }
+    // Wayland wl-paste
+    if _, err := exec.LookPath("wl-paste"); err == nil {
+        cmd := exec.Command("wl-paste", "-n")
+        out, err := cmd.CombinedOutput()
+        if err == nil { return string(out), nil }
+    }
+    // X11 xclip
+    if _, err := exec.LookPath("xclip"); err == nil {
+        cmd := exec.Command("xclip", "-selection", "clipboard", "-o")
+        out, err := cmd.CombinedOutput()
+        if err == nil { return string(out), nil }
+    }
+    // X11 xsel
+    if _, err := exec.LookPath("xsel"); err == nil {
+        cmd := exec.Command("xsel", "--clipboard", "--output")
+        out, err := cmd.CombinedOutput()
+        if err == nil { return string(out), nil }
+    }
+    return "", errors.New("no clipboard backend found (install wl-clipboard or xclip)")
+}
+
+func setClipboardText(s string) error {
+    if runtime.GOOS == "windows" {
+        cmd := exec.Command("powershell", "-NoProfile", "-Command", "Set-Clipboard")
+        cmd.Stdin = bytes.NewBufferString(s)
+        if out, err := cmd.CombinedOutput(); err != nil {
+            return fmt.Errorf("Set-Clipboard: %v (%s)", err, string(out))
+        }
+        return nil
+    }
+    if _, err := exec.LookPath("wl-copy"); err == nil {
+        cmd := exec.Command("wl-copy")
+        cmd.Stdin = bytes.NewBufferString(s)
+        if out, err := cmd.CombinedOutput(); err != nil {
+            return fmt.Errorf("wl-copy: %v (%s)", err, string(out))
+        }
+        return nil
+    }
+    if _, err := exec.LookPath("xclip"); err == nil {
+        cmd := exec.Command("xclip", "-selection", "clipboard")
+        cmd.Stdin = bytes.NewBufferString(s)
+        if out, err := cmd.CombinedOutput(); err != nil {
+            return fmt.Errorf("xclip: %v (%s)", err, string(out))
+        }
+        return nil
+    }
+    if _, err := exec.LookPath("xsel"); err == nil {
+        cmd := exec.Command("xsel", "--clipboard", "--input")
+        cmd.Stdin = bytes.NewBufferString(s)
+        if out, err := cmd.CombinedOutput(); err != nil {
+            return fmt.Errorf("xsel: %v (%s)", err, string(out))
+        }
+        return nil
+    }
+    return errors.New("no clipboard backend found (install wl-clipboard or xclip)")
+}
+


### PR DESCRIPTION
### **User description**
This PR completes the v1 user‑facing sync flow:\n\n- New modes: , , and  (recommended).\n- Clipboard integration:\n  - Windows via PowerShell (Get-Clipboard/Set-Clipboard).\n  - Linux via  (Wayland) or / (X11).\n- Local echo prevention using a simple hash to ignore remote‑applied updates.\n- Large text: watch spills to temp file and uploads via /upload; recv downloads and applies.\n- Docs: README usage and dependencies; TODO marks done.\n\nNotes\n- Only text/* clips are applied to the clipboard in v1. Non-text clips are logged.\n- No CGO required; relies on external tools on Linux.\n\nCI: no server changes. CLI builds and tests pass locally.


___

### **PR Type**
Enhancement


___

### **Description**
- Add clipboard sync modes: `recv`, `watch`, and `sync`

- Cross-platform clipboard integration (Windows PowerShell, Linux tools)

- Local echo prevention using hash-based deduplication

- Large text handling via temp files and upload


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Local Clipboard"] -- "watch mode" --> B["CLI Watch Loop"]
  B -- "send via WebSocket" --> C["Server"]
  C -- "receive via WebSocket" --> D["CLI Recv Apply"]
  D -- "apply to clipboard" --> E["Remote Clipboard"]
  F["Hash Tracker"] -- "prevent echo" --> B
  D -- "mark remote hash" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>clipboard.go</strong><dd><code>Cross-platform clipboard integration functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clients/cli/clipboard.go

<ul><li>Cross-platform clipboard read/write functions<br> <li> Windows PowerShell integration (Get-Clipboard/Set-Clipboard)<br> <li> Linux support for wl-clipboard, xclip, and xsel<br> <li> Error handling for missing clipboard backends</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/13/files#diff-c85bcc7c02c5b22ac392df838347380e45ea969828dc94430da9a4858e79a3c8">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>CLI clipboard sync modes implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

clients/cli/main.go

<ul><li>Add recv, watch, and sync CLI modes<br> <li> Implement clipboard polling and WebSocket communication<br> <li> Local echo prevention using hash-based deduplication<br> <li> Large text handling via temporary files<br> <li> Connection retry logic for new modes</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/13/files#diff-238635e863fc0237038d369e3eafcdcee4af6ce019ac0450c7cab10e112524e6">+178/-7</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update CLI documentation for sync modes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document new CLI modes (recv, watch, sync)<br> <li> Add clipboard dependencies for Windows and Linux<br> <li> Update usage examples and requirements</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/13/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TODO.md</strong><dd><code>Update TODO completion status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

TODO.md

<ul><li>Mark clipboard watch/recv features as completed<br> <li> Mark large clips upload/download as completed</ul>


</details>


  </td>
  <td><a href="https://github.com/MiguelAguiarDEV/clip-sync/pull/13/files#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

